### PR TITLE
Added AWS Well-Architected Security Workshop, removed out of date resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A list of free cloud native security learning labs. Includes CTF, self-hosted wo
 | [Pwned Labs](https://pwnedlabs.io) | AWS | Author-hosted Guided Labs, CTF | [Ian Austin](https://www.linkedin.com/in/ian-austin-a42002156/) | Requires account registration; Commercial paid subscriptions; free hosted labs for learning cloud security |
 | [The Big IAM Challenge](https://bigiamchallenge.com/)    | AWS | Author-hosted CTF Challenge | [Wiz](https://www.wiz.io)  | CTF challenge to identify and exploit IAM misconfigurations |
 | [CloudSec Tidbits](https://github.com/doyensec/cloudsec-tidbits/) | AWS | Self-hosted Challenge | [Doyensec](https://doyensec.com/)  | Three web app security flaws specific to AWS cloud, self-hosted with terraform  |
-| [Pentesting.Cloud](https://pentesting.cloud/)    | AWS | Self-hosted, Author-hosted CTF labs | [Nicholas Gilbert](https://www.linkedin.com/in/nicksecurity/)  | 17 free labs, requires registration, some labs are bring your own AWS account and use cloudformation to create |
+| [AWS Well-Architected Security Workshop](https://catalog.workshops.aws/well-architected-security/en-US)    | AWS | Self-hosted, guided labs | AWS Well-Architected  | Several hands-on-labs to help you learn, measure, and improve the security of your architecture using best practices from the Security pillar of the AWS Well-Architected Framework. |
 | [AWS CIRT Workshop](https://aws.amazon.com/blogs/security/aws-cirt-announces-the-release-of-five-publicly-available-workshops/)    | AWS | Self-hosted, guided lab |  AWS CIRT | Build with Cloudformation, explore 5 common incident response scenarios observed by AWS CIRT |
 | [CloudGoat](https://github.com/RhinoSecurityLabs/cloudgoat)    | AWS | Self-hosted, guided vulnerability lab |  Multiple, [Rhino Security Labs](https://rhinosecuritylabs.com/) | Python orchestration of terraform |
 | [Attacking and Defending Serverless Applications](https://attack-defend-serverless.sanscloudwars.com/)    | AWS | Self-hosted, guided vulnerability workshop |  [Ryan Nicholson](https://twitter.com/ryananicholson) | Attack and defend a Lambda that you build in your own AWS account with author provided terraform |
@@ -58,8 +58,6 @@ A list of free cloud native security learning labs. Includes CTF, self-hosted wo
 
 [CloudSec Tidbits](https://github.com/doyensec/cloudsec-tidbits/):  Three web app security flaws specific to AWS cloud, self-hosted with terraform.
 
-[Pentesting.Cloud](https://pentesting.cloud):  17 free labs.  Requires site registration.
-
 [AWS CIRT Workshop](https://aws.amazon.com/blogs/security/aws-cirt-announces-the-release-of-five-publicly-available-workshops/):  Build in your own AWS account and explore 5 common incident response scenarios as seen by the AWS CIRT team.
 
 [CloudGoat](https://github.com/RhinoSecurityLabs/cloudgoat):  Vulnerable by design AWS security labs with guided walkthrough.
@@ -81,6 +79,8 @@ A list of free cloud native security learning labs. Includes CTF, self-hosted wo
 [DVCA](https://github.com/m6a-UdS/dvca): Deploy a Damn Vulnerable Cloud Application in your own AWS account to practice privilege escalation.
 
 [lambhack](https://github.com/wickett/lambhack): Deploy a very vulnerable AWS lambda serverless application in your AWS account.
+
+[AWS Well-Architected Security Workshop](https://catalog.workshops.aws/well-architected-security/en-US): Self-deployed hands-on-labs to help you learn, measure, and improve the security of your architecture using best practices from the Security pillar of the AWS Well-Architected Framework.
 
 
 ## Azure


### PR DESCRIPTION
Added information about the AWS Well-Architected Security Workshop, removed `pentesting.cloud` resource because it is now available anymore